### PR TITLE
update "current system" with latest available components

### DIFF
--- a/main/overview.md
+++ b/main/overview.md
@@ -2,31 +2,23 @@
 
 The OpenEnergyMonitor system has the capability to monitor electrical energy use / generation, temperature and humidity.
 
-The system is made up of five main units. These can be configured to work for a variety of applications. The system is fully open-source, both hardware and software. All hardware is based on the [Arduino](http://www.arduino.cc/) and [Raspberry Pi](http://raspberrypi.org) platforms.
+The system is made up of four main units. These can be configured to work for a variety of applications. The system is fully open-source, both hardware and software. All hardware is based on the [Arduino](http://www.arduino.cc/) and [Raspberry Pi](http://raspberrypi.org) platforms.
 
 % ![image](img/oemfpsystemdiagram.png)
 
 <p><b>Current system</b></p>
 
-```{image} img/emontx4-min.png
-:width: 50px
-:align: left
-```
-
-**emonTx v4:** A 6x circuit energy monitoring node. Transmits data via an inbuilt 433MHz radio to an emonBase. It can also send data via a Wi-Fi extension board or directly via USB.<br><br>
-
 ```{image} img/emonVs-min.png
 :width: 50px
 :align: left
 ```
-**emonVs v1.1:**<br>Combined precision voltage sensor and power supply.<br><br>
+**emonVs v1.3.2:**<br>Combined precision voltage sensor and power supply, sends voltage data and power to the emonPi2 via RJ45.<br><br>
 
-```{image} img/emonbase-min.png
+```{image} img/emonpi-min.png
 :width: 50px
 :align: left
 ```
-**emonBase:** A Raspberry Pi base-station that receives data sent from the emonTx4. Hosts the emonCMS software for full local data logging and visualisation capability. With new direct SPI RFM69 radio transceiver.
-<br><br>
+**emonPi2 v2.0.1:**<br>A Raspberry Pi shield offering 6x clip-on CT current sensor inputs, Real/Active power measurement, temperature sensing and radio transreceiver.<br><br>
 
 ```{image} img/ctsensor.png
 :width: 50px
@@ -45,6 +37,20 @@ The system is made up of five main units. These can be configured to work for a 
 ---
 
 <p><b>Earlier hardware</b></p>
+
+```{image} img/emontx4-min.png
+:width: 50px
+:align: left
+```
+
+**emonTx v4:** A 6x circuit energy monitoring node. Transmits data via an inbuilt 433MHz radio to an emonBase. It can also send data via a Wi-Fi extension board or directly via USB.<br><br>
+
+```{image} img/emonbase-min.png
+:width: 50px
+:align: left
+```
+**emonBase:** A Raspberry Pi base-station that receives data sent from the emonTx4. Hosts the emonCMS software for full local data logging and visualisation capability. With new direct SPI RFM69 radio transceiver.
+<br><br>
 
 ```{image} img/emonpi-min.png
 :width: 50px


### PR DESCRIPTION
This is the first page people see when coming to the OEM docs and it says the current system is formed by devices that are no longer for sale on the OEM shop (and the emonPi2 is so cool but not even mentioned 🤩 ) so I thought it'd be useful to update that information.



**Before**:

![image](https://github.com/openenergymonitor/docs/assets/4906291/b8230db0-2ab5-464f-ad1c-aeffa286e793)



**After**: 

![image](https://github.com/openenergymonitor/docs/assets/4906291/a8215606-a9a7-4f5a-8c2c-56ea51da8de6)

