### PR TITLE
Adds missing dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ See: [http://www.sphinx-doc.org/en/master/usage/installation.html](http://www.sp
 
 ### 4. Install Plugins
 
-    pip3 install m2r myst-parser
+    pip3 install m2r myst-parser sphinx_copybutton
 
 ### 5. Build the docs
 


### PR DESCRIPTION
When I installed this on my machine there were a few issues, I thought they were MacOS-only issues but doing this [in Ubuntu inside a Github Action](https://github.com/RosanaRufer/docs/pull/2/files) also complained about this dependency missing.

I'm currently setting up this action in another branch in my fork with the idea of making the documentation project easier to preview before merging and generally easier to use (also to learn how to do it)